### PR TITLE
feat: implemented possibility of refreshing all history metrics

### DIFF
--- a/android/src/main/kotlin/com/quantactions/qa_flutter_plugin/event_channel_handlers/MetricAndTrendStreamHandler.kt
+++ b/android/src/main/kotlin/com/quantactions/qa_flutter_plugin/event_channel_handlers/MetricAndTrendStreamHandler.kt
@@ -53,6 +53,7 @@ class MetricAndTrendStreamHandler(
             val metric = params["metric"] as String
             val metricToAsk = QAFlutterPluginMetricMapper.getMetric(metric)
             val dateIntervalType = params["metricInterval"] as? String
+            val refresh = params["refresh"] as? Boolean
             val fromLocalDate =
                 getFromDateInterval(dateIntervalType)
             val toLocalDate = LocalDate.now()
@@ -105,7 +106,8 @@ class MetricAndTrendStreamHandler(
                             .toEpochMilli(),
                         to = toLocalDate.atStartOfDay().plusDays(30)
                             .toInstant(ZoneOffset.UTC)
-                            .toEpochMilli()
+                            .toEpochMilli(),
+                        refresh = refresh ?: false
                     ).collect {
                         val rewindDays = ChronoUnit.DAYS.between(
                             fromLocalDate,

--- a/lib/quantactions_flutter_plugin.dart
+++ b/lib/quantactions_flutter_plugin.dart
@@ -208,10 +208,12 @@ class QAFlutterPlugin {
   Stream<TimeSeries<dynamic>> getMetric({
     required MetricType metric,
     required MetricInterval interval,
+    bool refresh = false,
   }) {
     return _metricRepository.getMetric(
       metric: metric,
       interval: interval,
+      refresh: refresh,
     );
   }
 

--- a/lib/src/data/metric/providers/metric_provider.dart
+++ b/lib/src/data/metric/providers/metric_provider.dart
@@ -6,6 +6,7 @@ abstract class MetricProvider {
   Stream<dynamic> getMetric({
     required MetricType metric,
     required MetricInterval interval,
+    bool refresh
   });
 
   /// Get metric sample (stream) for a given metric and interval, expect up-to-date

--- a/lib/src/data/metric/providers/metric_provider_impl.dart
+++ b/lib/src/data/metric/providers/metric_provider_impl.dart
@@ -39,6 +39,7 @@ class MetricProviderImpl implements MetricProvider {
   Stream<dynamic> getMetric({
     required MetricType metric,
     required MetricInterval interval,
+    bool refresh = false
   }) {
     return _sdkMethodChannel.callEventChannel(
       method: SupportedMethods.getMetric,
@@ -46,6 +47,7 @@ class MetricProviderImpl implements MetricProvider {
       params: <String, dynamic>{
         'metric': metric.id,
         'metricInterval': interval.id,
+        'refresh': refresh,
       },
       metricType: metric,
     );

--- a/lib/src/data/metric/repositories/metric_repository_impl.dart
+++ b/lib/src/data/metric/repositories/metric_repository_impl.dart
@@ -17,11 +17,13 @@ class MetricRepositoryImpl implements MetricRepository {
   Stream<TimeSeries<dynamic>> getMetric({
     required MetricType metric,
     required MetricInterval interval,
+    bool refresh = false,
   }) {
     return _mapStream(
       stream: _metricProvider.getMetric(
         metric: metric,
         interval: interval,
+        refresh: refresh,
       ),
       metric: metric,
     );

--- a/lib/src/domain/repositories/metric_repository.dart
+++ b/lib/src/domain/repositories/metric_repository.dart
@@ -6,6 +6,7 @@ abstract class MetricRepository {
   Stream<TimeSeries<dynamic>> getMetric({
     required MetricType metric,
     required MetricInterval interval,
+    bool refresh,
   });
 
   /// Get metric sample (stream) for a given metric and interval, expect up-to-date


### PR DESCRIPTION
In android by default the network call only refreshes the last 60 days of metrics, unless refreshing is force. Now the refreshing option is also available in the flutter plugin 